### PR TITLE
docs: fix a typo regarding named middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Assuming you have an AdonisJS app that's not completely an API i.e a fullstack a
 ```ts
 // start/kernel.ts
 Server.middleware.registerNamed({
-  treblle: [() => import('treblle-adonisjs')
+  treblle: () => import('treblle-adonisjs')
 })
 ```
 


### PR DESCRIPTION
This fix seeks to address a typo within the README file which could mislead users and cause bugs in their integration workflow

- Removed the square bracket which is only applicable for global middleware and not named middleware in AdonisJS